### PR TITLE
fix 'hibernate.dialect' not set

### DIFF
--- a/src/main/java/calories/tracker/config/root/DevelopmentConfiguration.java
+++ b/src/main/java/calories/tracker/config/root/DevelopmentConfiguration.java
@@ -56,6 +56,7 @@ public class DevelopmentConfiguration {
         jpaProperties.put("hibernate.show_sql", "true");
         jpaProperties.put("hibernate.format_sql", "true");
         jpaProperties.put("hibernate.use_sql_comments", "true");
+        jpaProperties.put("hibernate.dialect", "org.hibernate.dialect.PostgreSQLDialect");
         entityManagerFactoryBean.setJpaPropertyMap(jpaProperties);
 
         return entityManagerFactoryBean;


### PR DESCRIPTION
The error "org.hibernate.HibernateException: Access to DialectResolutionInfo cannot be null when 'hibernate.dialect' not set" occur when use development profile.
